### PR TITLE
docs: actualizar README con convenciones de ramas

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,15 @@ Aplicación web para venta de entradas utilizada en la cursada 2025 de Ingenier�
 ## Iniciar app
 
 `python manage.py runserver`
+
+## Convenciones de ramas (Branch Naming)
+
+Para mantener un orden claro en el repositorio, seguimos estas convenciones para nombrar las ramas, usando guion bajo `_` (**snake_case**) para separar palabras dentro del nombre, y slash `/` para separar el prefijo del nombre de la rama:
+
+| Prefijo    | Uso principal                                            | Ejemplo                     |
+|------------|---------------------------------------------------------|-----------------------------|
+| `feature/` | Nuevas funcionalidades o mejoras                         | `feature/agregar_login`     |
+| `fix/`     | Corrección de errores o bugs                             | `fix/arreglar_error_login`  |
+| `infra/`   | Cambios en infraestructura y configuraciones técnicas   | `infra/configurar_dockerfile`|
+| `refactor/`| Cambios en código para mejorar estructura o legibilidad sin agregar ni arreglar funcionalidad | `refactor/limpieza_codigo`  |
+| `docs/`    | Cambios o mejoras en la documentación                    | `docs/actualizar_readme`    |


### PR DESCRIPTION
### ¿Qué se hizo?

Se actualizó el archivo README.md para incluir las convenciones de nomenclatura de ramas (branch naming), especificando los prefijos usados y ejemplos claros en español con snake_case.

### ¿Por qué se hizo?

Para mejorar la documentación del proyecto y estandarizar la forma en que los desarrolladores crean y nombran las ramas, facilitando el trabajo colaborativo y evitando confusiones.

### ¿Cómo se probó?

- Se verificó que el README se visualice correctamente en GitHub.
- Se revisó que la información sea clara y esté correctamente formateada.

### Consideraciones

- No afecta código ni funcionalidad, solo documentación.
- No requiere tests adicionales.