### PR TITLE
infra: Configurar CD para Deploy Continuo #21

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,8 +3,9 @@ name: Entrega Continua
 on:
   release:
     types: [published]
-  workflow_dispatch:  # <-- trigger manual para test, luego se puede eliminar
-
+  push:
+    branches:
+      - main
 
 jobs:
   deploy:
@@ -32,7 +33,6 @@ jobs:
         if: github.event_name != 'workflow_dispatch'
         run: echo "IMAGE_TAG=$(date '+%Y%m%d%H%M%S')" >> $GITHUB_ENV
 
-
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
@@ -40,7 +40,6 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/eventhub:latest,${{ secrets.DOCKERHUB_USERNAME }}/eventhub:${{ env.IMAGE_TAG }}
-
 
       - name: Deploy en Render
         env:


### PR DESCRIPTION
## ¿Qué se hizo?
Se editó el archivo de configuración cd.yml.
Se actualizó el workflow de Entrega Continua para que además de ejecutarse al publicar una release, también se dispare automáticamente al hacer push a la rama main.
Esto permite realizar Deploy Continuo luego de integrar cambios mediante un Pull Request.

## ¿Por qué se hizo?
Para cumplir con el punto 5 del proyecto (Deploy Continuo).
Su implementación permite que la aplicación se despliegue automáticamente en producción al mergear un PR hacia main.

## ¿Cómo se probó?
Se creó una rama específica para la tarea y se modificó temporalmente el trigger del workflow para probar el despliegue antes del merge.
Se verificó que el workflow construya y publique la imagen Docker en DockerHub correctamente y que Render reciba el webhook para desplegar la nueva versión.
Posteriormente se limpió la configuración temporal, dejando el workflow preparado para funcionar en producción.

Closes #21 

