### PR TITLE
Fix: Eliminar pruebas manuales en CD #24

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,12 +25,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Set IMAGE_TAG variable para pruebas manuales
-        if: github.event_name == 'workflow_dispatch'
-        run: echo "IMAGE_TAG=test" >> $GITHUB_ENV
-
       - name: Set IMAGE_TAG variable para releases
-        if: github.event_name != 'workflow_dispatch'
         run: echo "IMAGE_TAG=$(date '+%Y%m%d%H%M%S')" >> $GITHUB_ENV
 
       - name: Build and push


### PR DESCRIPTION
## ¿Qué se hizo?
Se editó el archivo de configuración cd.yml.
Se eliminaron pruebas manuales.

## ¿Por qué se hizo?
Para cumplir con el punto 5 del proyecto (Deploy Continuo).
Su implementación permite que la aplicación se despliegue automáticamente en producción al mergear un PR hacia main.

## ¿Cómo se probó?
Se creó una rama específica para la tarea y se modificó temporalmente el trigger del workflow para probar el despliegue antes del merge.
Se verificó que el workflow construya y publique la imagen Docker en DockerHub correctamente y que Render reciba el webhook para desplegar la nueva versión.
Posteriormente se limpió la configuración temporal, dejando el workflow preparado para funcionar en producción.

Closes #24