### PR TITLE
infra: Configura WhiteNoise y recolecta archivos estáticos en Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ RUN apt-get update \
 # Copiamos el resto del proyecto
 COPY . .
 
+# Recolectamos los archivos estáticos
+RUN python manage.py collectstatic --noinput
+
 # Exponemos el puerto
 EXPOSE 8000
 

--- a/eventhub/settings.py
+++ b/eventhub/settings.py
@@ -47,6 +47,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -105,11 +106,7 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-
-STATIC_URL = "/static/"
-
 # Bootstrap 5
-STATICFILES_DIRS = [BASE_DIR / "static"]
 
 # Internationalization
 # https://docs.djangoproject.com/en/5.0/topics/i18n/
@@ -127,7 +124,11 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.0/howto/static-files/
 
-STATIC_URL = "static/"
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+
+STATIC_URL = "/static/"
+
+STATICFILES_DIRS = [BASE_DIR / "static"]
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ typing_extensions==4.13.2
 tzdata==2025.2
 urllib3==2.4.0
 gunicorn==21.2.0
+whitenoise==6.9.0


### PR DESCRIPTION
## ¿Qué se hizo?
Se configuró `WhiteNoise` en Django para servir archivos estáticos en producción sin necesidad de un servidor web adicional.
Se agregó el comando `collectstatic --noinput` en el Dockerfile para recopilar los archivos estáticos durante la construcción de la imagen Docker.
Se corrigieron y acomodaron las rutas estáticas en `settings.py`.

## ¿Por qué se hizo?
Porque al usar Gunicorn (u otro servidor WSGI) Django no sirve archivos estáticos automáticamente, lo que impedía acceder a recursos como los JSON de provincias y ciudades desde la app en producción.
La integración de `WhiteNoise` permite servir estos archivos sin necesidad de configurar un servidor externo como nginx, simplificando el despliegue.
La recolección de archivos estáticos en la imagen Docker garantiza que estos estén disponibles en la ruta correcta al momento de iniciar el contenedor.

## ¿Cómo se probó?
Se construyó la imagen Docker con los cambios y se levantó el contenedor.
Se accedió a la URL `http://localhost:8000/static/data/argentina_states.json` (y otras similares) para verificar que los archivos estáticos se sirvieran correctamente.
Se probó la funcionalidad en la interfaz de formulario donde se usan estos JSON para la carga dinámica de provincias y ciudades, comprobando que los datos se carguen sin errores.
Se verificó que no se generen errores de rutas estáticas durante la ejecución de la aplicación.