### PR TITLE
fix: implementar render hook en CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - fix/implementar_render_hook
 
 jobs:
   deploy:
@@ -37,11 +38,4 @@ jobs:
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/eventhub:latest,${{ secrets.DOCKERHUB_USERNAME }}/eventhub:${{ env.IMAGE_TAG }}
 
       - name: Deploy en Render
-        env:
-          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
-          SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID }}
-        run: |
-          curl -X POST "https://api.render.com/v1/services/$SERVICE_ID/deploys" \
-            -H "Authorization: Bearer $RENDER_API_KEY" \
-            -H "Content-Type: application/json" \
-            -d '{}'
+        run: curl -X POST ${{ secrets.RENDER_HOOK }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - fix/implementar_render_hook
 
 jobs:
   deploy:


### PR DESCRIPTION
## ¿Qué se hizo?

- Se agregó el hook de despliegue en Render en el workflow de Entrega Continua para que al publicar una release o hacer push a `main` se actualice automáticamente la app en Render.

## ¿Por qué se hizo?

- Antes el deploy en Render no se ejecutaba automáticamente tras la publicación de la imagen Docker.
- Ahora, con el webhook configurado, el despliegue se automatiza, asegurando que la app esté siempre actualizada con la última imagen publicada, evitando pasos manuales.

## ¿Cómo se probó?

- Se creó una release de prueba y se verificó que el webhook de Render se activara correctamente, actualizando la aplicación.


